### PR TITLE
configureable stream defaulting to process.stdout

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -22,6 +22,7 @@ class Signale {
     this._scopeName = options.scope || '';
     this._timers = options.timers || new Map();
     this._types = Object.assign(types, this._customTypes);
+    this._stream = options.stream || process.stdout;
 
     Object.keys(this._types).forEach(type => {
       this[type] = this._logger.bind(this, type);
@@ -80,7 +81,7 @@ class Signale {
   }
 
   _log(message) {
-    process.stdout.write(message + '\n');
+    this._stream.write(message + '\n');
   }
 
   _formatDate() {


### PR DESCRIPTION
This PR provides a mechanism for providing a writable stream to a Signale instance. The most common use would be to pass `process.stdout` instead of the default `process.stderr` although you could do other things like write to a socket if your client can understand ANSI escape sequences.