### PR TITLE
Bug: Update configuration variable name to `_config`

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -192,7 +192,7 @@ class Signale {
   }
 
   config(configObj) {
-    this.configuration = configObj;
+    this._config = configObj;
   }
 
   scope(...name) {


### PR DESCRIPTION
Setting the configuration via `signale.config()` won't update the configuration as it is setting `this.configuration` which is unused in the code. I've changed this to `this._config` so it can be applied.
