### PR TITLE
Added support for multiple streams & optional streams per logger. Fixes #26

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -78,11 +78,11 @@ class Signale {
   }
 
   _logger(type, ...messageObj) {
-    this._log(this._buildSignale(this._types[type], ...messageObj));
+    this._log(this._buildSignale(this._types[type], ...messageObj), this._types[type].stream);
   }
 
-  _log(message) {
-    this._stream.write(message + '\n');
+  _log(message, stream = this._stream) {
+    stream.write(message + '\n');
   }
 
   _formatDate() {

--- a/signale.js
+++ b/signale.js
@@ -81,8 +81,14 @@ class Signale {
     this._log(this._buildSignale(this._types[type], ...messageObj), this._types[type].stream);
   }
 
-  _log(message, stream = this._stream) {
-    stream.write(message + '\n');
+  _log(message, streams = this._stream) {
+    this._formatStream(streams).forEach(stream => {
+      stream.write(message + '\n');
+    });
+  }
+
+  _formatStream(stream) {
+    return Array.isArray(stream) ? stream : [stream];
   }
 
   _formatDate() {

--- a/types.js
+++ b/types.js
@@ -5,7 +5,8 @@ module.exports = {
   error: {
     badge: figures.cross,
     color: 'red',
-    label: 'error'
+    label: 'error',
+    stream: process.stderr
   },
   fatal: {
     badge: figures.cross,

--- a/types.js
+++ b/types.js
@@ -5,8 +5,7 @@ module.exports = {
   error: {
     badge: figures.cross,
     color: 'red',
-    label: 'error',
-    stream: process.stderr
+    label: 'error'
   },
   fatal: {
     badge: figures.cross,


### PR DESCRIPTION
This would allow you to pass a stream as a property when configuring types to use that stream over the default one. 

This does add a property to types that in its current state could not be represented by the config in package.json. If you feel this is necessary I can change it that type.stream is stream identifier and then have an api-only option of a map of identifier to implementation.

If you are happy with the current implementation I will crack on with updating the documentation.

Also, love the library in both functionality and ease of contribution!

EDIT: This now also fixes #26 by providing the ability to have an array of streams as either `options.stream` or `type.stream`