### PR TITLE
fix: handle anonymous callsites. (fixes #5)

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -62,11 +62,13 @@ class Signale {
     const {stack} = new Error();
     Error.prepareStackTrace = _;
 
-    const callers = stack.map(x => path.basename(x.getFileName()));
+    const callers = stack.map(x => x.getFileName());
 
-    return callers.find(x => {
+    const firstExternalFilePath = callers.find(x => {
       return x !== callers[0];
     });
+
+    return firstExternalFilePath ? path.basename(firstExternalFilePath) : 'anonymous';
   }
 
   get packageConfiguration() {


### PR DESCRIPTION
Fixes https://github.com/klauscfhq/signale/issues/5 by ensuring we only call path.basename on callsites with a valid file path. The find below should act as a filter of these falsy (usually null from what I've seen) values.

In the unlikely case that there is no suitable file path, set the filename as unknown.