### PR TITLE
Enabled deep-merging between default & custom types

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -3,8 +3,8 @@ const path = require('path');
 const chalk = require('chalk');
 const figures = require('figures');
 const pkgConf = require('pkg-conf');
-const types = require('./types');
 const pkg = require('./package.json');
+const defaultTypes = require('./types');
 
 const defaults = pkg.options.default;
 const namespace = pkg.name;
@@ -21,9 +21,9 @@ class Signale {
     this._customTypes = Object.assign({}, options.types);
     this._scopeName = options.scope || '';
     this._timers = options.timers || new Map();
-    this._types = Object.assign({}, types, this._customTypes);
+    this._types = this._mergeTypes(defaultTypes, this._customTypes);
     this._stream = options.stream || process.stdout;
-    this._longestLabel = types.start.label.length;
+    this._longestLabel = defaultTypes.start.label.length;
 
     Object.keys(this._types).forEach(type => {
       this[type] = this._logger.bind(this, type);
@@ -76,6 +76,13 @@ class Signale {
 
   set configuration(configObj) {
     this._config = Object.assign(this.packageConfiguration, configObj);
+  }
+
+  _mergeTypes(standard, custom) {
+    Object.keys(custom).forEach(type => {
+      standard[type] = Object.assign({}, standard[type], custom[type]);
+    });
+    return standard;
   }
 
   _logger(type, ...messageObj) {


### PR DESCRIPTION
This PR enables the selective override of user-specified attributes on the default loggers, by deep merging the custom logger types against the default ones, and preserving the values of all unmodified attributes, e.g:

```js
// example.js
const {Signale} = require('signale');

const options = {
  types: {
    error: {
      // Here `yellow` will override only the default `red` color 
      // and all other default attributes will stay unmodified
      color: 'yellow'
    }
  }
};

const signale = new Signale(options);
console.log(signale._types);
```

The `error` type logger will now hold the following expected attributes:

```js
{
  // ...
  error: {
    badge: '✖',
    color: 'yellow',
    label: 'error'
  },
  // ...
}
```

Currently, `error` receives only the color attribute, losing all other default ones:

```js
{
  // ...
  error: {
    color: 'yellow'
  },
  // ...
}
```
 