### PR TITLE
 Added new progress bar. Fixes #35

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,37 @@ setTimeout(() => {
   <img alt="Timers" src="media/timers.png" width="60%">
 </div>
 
+### Progress Bar
+
+A progress bar can be created using the `progress()` function while passing an object with a 'label' property. The `progress()` function will act like a normal logger if this object is not given. To get the best effect use the interactive signale option.
+
+```js
+const {Signale} = require('./index');
+
+const signale = new Signale({interactive: true});
+signale.progress({label:'Downloading', current: 5, total: 10});
+```
+
+##### `label`
+
+- Type: `String`
+
+The label to be added before the progress bar.
+
+##### `current`
+
+- Type: `int`
+- Default: `0`
+
+Amount competed.
+
+##### `total`
+
+- Type: `int`
+- Default: `0`
+
+Total progress needed.
+
 ## Configuration
 
 ### Global

--- a/readme.md
+++ b/readme.md
@@ -280,7 +280,7 @@ setTimeout(() => {
 A progress bar can be created using the `progress()` function while passing an object with a 'label' property. The `progress()` function will act like a normal logger if this object is not given. To get the best effect use the interactive signale option.
 
 ```js
-const {Signale} = require('./index');
+const {Signale} = require('signale');
 
 const signale = new Signale({interactive: true});
 signale.progress({label:'Downloading', current: 5, total: 10});

--- a/signale.js
+++ b/signale.js
@@ -90,6 +90,17 @@ class Signale {
   }
 
   _logger(type, ...messageObj) {
+    if (type === 'progress' && Object.prototype.hasOwnProperty.call(messageObj[0], 'label')) {
+      let base = '';
+      let i = 0;
+      for (; i < messageObj[0].current || 0; i++) {
+        base += '=';
+      }
+      for (; i < messageObj[0].total || 0; i++) {
+        base += ' ';
+      }
+      messageObj[0] = messageObj[0].label + ' [' + base + '] ' + (Math.round((messageObj[0].current / messageObj[0].total) * 100) || 0) + '%';
+    }
     this._log(this._buildSignale(this._types[type], ...messageObj), this._types[type].stream);
   }
 

--- a/types.js
+++ b/types.js
@@ -77,6 +77,11 @@ module.exports = {
     color: 'yellow',
     label: 'watching'
   },
+  progress: {
+    badge: figures.pointer,
+    color: 'yellowBright',
+    label: 'progress'
+  },
   log: {
     badge: '',
     color: '',


### PR DESCRIPTION
This new feature can be used by calling the `progress()` function while passing an object with a 'label' property. The label is added before the progress bar. The progress bar is made up of equal signs and spaces corresponding to the given completed and total respectively. Example:
```js
const {Signale} = require('signale');

const signale = new Signale({interactive: true});
signale.progress({label:'Downloading', current: 5, total: 10});
```
Will result in:
```
❯  progress  Downloading [=====     ] 50%
```
<!--

Thank you for taking the time to contribute to Signale!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/signale/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project!

-->
