### PR TITLE
Check if Error object has stack property. Fixes #34.

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -192,7 +192,7 @@ class Signale {
       }
     }
 
-    if (msg instanceof Error) {
+    if (msg instanceof Error && typeof msg.stack !== 'undefined') {
       const [name, ...rest] = msg.stack.split('\n');
       if (this._config.underlineMessage) {
         signale.push(chalk.underline(name));

--- a/signale.js
+++ b/signale.js
@@ -192,7 +192,7 @@ class Signale {
       }
     }
 
-    if (msg instanceof Error && typeof msg.stack !== 'undefined') {
+    if (msg instanceof Error && msg.stack) {
       const [name, ...rest] = msg.stack.split('\n');
       if (this._config.underlineMessage) {
         signale.push(chalk.underline(name));


### PR DESCRIPTION
This PR addresses the problem described in https://github.com/klauscfhq/signale/issues/34

When trying to log an Error with an undefined stack trace, now `signale` correctly logs the error name and ignores the `stack` property.

Before:
```
const [name, ...rest] = msg.stack.split('\n');
                                        ^
TypeError: Cannot read property 'split' of undefined
```

After:
```
✖  error     SyntaxError
```