### PR TITLE
Add `isEnabled()` API Method for Logger Enablement Check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -749,6 +749,28 @@ signale.success('foo');
 //=> ✔  success  foo
 ```
 
+#### signale.`isEnabled()`
+
+Checks whether the logging functionality of a specific instance is enabled.
+
+```js
+const signale = require('signale');
+
+signale.success('foo');
+//=> ✔  success  foo
+
+signale.isEnabled();
+// => true
+
+signale.disable();
+
+signale.success('foo');
+//=>
+
+signale.isEnabled();
+// => false
+```
+
 ## Development
 
 For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/signale/blob/master/contributing.md).

--- a/signale.js
+++ b/signale.js
@@ -47,10 +47,6 @@ class Signale {
     });
   }
 
-  get isEnabled() {
-    return !this._disabled;
-  }
-
   get date() {
     return new Date().toLocaleDateString();
   }
@@ -256,7 +252,7 @@ class Signale {
   }
 
   _log(message, streams = this._stream) {
-    if (this.isEnabled) {
+    if (this.isEnabled()) {
       this._formatStream(streams).forEach(stream => {
         this._write(stream, message);
       });
@@ -293,6 +289,10 @@ class Signale {
 
   enable() {
     this._disabled = false;
+  }
+
+  isEnabled() {
+    return !this._disabled;
   }
 
   scope(...name) {


### PR DESCRIPTION
### Preview

Adds the ability to check  whether the logging functionality of a specific `Signale` instance is enabled, by utilizing the `isEnabled()` method:

 ```js
const signale = require('signale');

signale.success('foo');
//=> ✔  success  foo

 signale.isEnabled();
// => true

 signale.disable();

 signale.success('foo');
//=>

 signale.isEnabled();
// => false
```

### Changes

- Exported `isEnabled()` as an API method. https://github.com/klauscfhq/signale/commit/b3454e1533d5afe0376cddc827a698274487b748
- Updated documentation. https://github.com/klauscfhq/signale/commit/5f7b6ff088ffbfe5512324aa56ce70fd3b231e05