### PR TITLE
Fixed #65

### DIFF
--- a/types.js
+++ b/types.js
@@ -64,7 +64,7 @@ module.exports = {
   },
   debug: {
     badge: figures('⬤'),
-    color: 'red',
+    color: 'blue',
     label: 'debug'
   },
   await: {


### PR DESCRIPTION
signale.debug() is now colored in blue like in the screenshots

<!--

Thank you for taking the time to contribute to Signale!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/signale/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project!

-->
